### PR TITLE
Support Lumen & Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Repoist
 
-Laravel 5 repository generator.
+Laravel and Lumen 5 repository generator.
 
 ## Usage
 
@@ -17,7 +17,11 @@ You'll only want to use these generators for local development, so you don't wan
 ```php
 public function register()
 {
-	if ($this->app->isLocal()) {
+	if ($this->app->environment('local')) {
+        /**
+         * Uncomment the following line in Lumen
+         */
+		//$this->app->configure('repoist');
 		$this->app->register('Kurt\Repoist\RepoistServiceProvider');
 	}
 }
@@ -25,7 +29,9 @@ public function register()
 
 ### Step 3: Publish and edit the configurations
 
-Run `php artisan vendor:publish` from the console to configure the Repoist according to your needs. 
+**In Laravel:** Run `php artisan vendor:publish` from the console to configure the Repoist according to your needs.
+ 
+**In Lumen:** Manually copy the config file `vendor/ozankurt/repoist/src/config/repoist.php` to your `config` directory
 
 ### Step 4: Run Artisan!
 
@@ -47,7 +53,7 @@ Will output:
 - `app/Interfaces/Task/TaskRepositoryInterface.php` (contract)
 - `app/Repositories/Task/TaskRepositoryEloquent.php`
 
-### Repositories With Schema
+### Repositories With Schema (Laravel Only)
 
 ```
 php artisan make:repository Task -m

--- a/src/Commands/RepositoryMakeCommand.php
+++ b/src/Commands/RepositoryMakeCommand.php
@@ -4,7 +4,6 @@ namespace Kurt\Repoist\Commands;
 use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Composer;
 
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
@@ -42,7 +41,7 @@ class RepositoryMakeCommand extends Command
     protected $meta;
 
     /**
-     * @var Composer
+     * @var \Illuminate\Foundation\Composer | \Illuminate\Support\Composer
      */
     private $composer;
 
@@ -50,14 +49,18 @@ class RepositoryMakeCommand extends Command
      * Create a new command instance.
      *
      * @param Filesystem $files
-     * @param Composer $composer
      */
-    public function __construct(Filesystem $files, Composer $composer)
+    public function __construct(Filesystem $files)
     {
         parent::__construct();
 
         $this->files = $files;
-        $this->composer = $composer;
+
+        if (class_exists(\Illuminate\Support\Composer::class)) {
+            $this->composer = app(\Illuminate\Support\Composer::class);
+        } else {
+            $this->composer = app(\Illuminate\Foundation\Composer::class);
+        }
     }
 
     /**
@@ -84,7 +87,7 @@ class RepositoryMakeCommand extends Command
             'contract' => $this->cleanNamespaces(config('repoist.paths.contract') . '/' . $this->meta['names']['subNamespace']),
             'eloquent' => $this->cleanNamespaces(config('repoist.paths.eloquent') . '/' . $this->meta['names']['subNamespace']),
             'model' => $this->cleanNamespaces(config('repoist.paths.model') . '/' . $this->meta['names']['subNamespace']),
-            ];
+        ];
     }
 
     /**
@@ -104,7 +107,7 @@ class RepositoryMakeCommand extends Command
             'contract' => './' . config('repoist.paths.contract') . '/' . $this->meta['names']['subPath'] . $this->meta['filenames']['contract'] . '.php',
             'eloquent' => './' . config('repoist.paths.eloquent') . '/' . $this->meta['names']['subPath'] . $this->meta['filenames']['eloquent'] . '.php',
             'model' => './' . config('repoist.paths.model') . '/' . $this->meta['names']['subPath'] . $this->meta['filenames']['model'] . '.php',
-            ];
+        ];
     }
 
     /**
@@ -116,7 +119,7 @@ class RepositoryMakeCommand extends Command
             'name' => preg_replace("/.*?([^\\\\\\/ ]*)$/", "$1", $this->argument('name')),
             'subNamespace' => preg_replace("/(.*?)(\\/?[^\\\\\\/ ]*)$/", "$1", $this->argument('name')),
             'subPath' => preg_replace("/(.*?)([^\\\\\\/ ]*)$/", "$1", $this->argument('name')),
-            ];
+        ];
     }
 
     /**


### PR DESCRIPTION
Add support to Lumen while supporting Laravel >= 5.0.0 (Composer class is instantiated either from the `\Illuminate\Support\` or `\Illuminate\Foundation\` namespaces).

Update README to include installation instructions for Lumen.