### PR TITLE
Fix Class does not exist when use laravel 5.4

### DIFF
--- a/src/Commands/RepositoryMakeCommand.php
+++ b/src/Commands/RepositoryMakeCommand.php
@@ -1,16 +1,16 @@
 <?php
 namespace Kurt\Repoist\Commands;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Composer;
 
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
 class RepositoryMakeCommand extends Command
 {
-    use AppNamespaceDetectorTrait;
+    use DetectsApplicationNamespace;
 
     /**
      * The console command name.


### PR DESCRIPTION
Hi! I fix the error when use laravel 5.4.
```sh
  [Symfony\Component\Debug\Exception\FatalErrorException]
  Trait 'Kurt\Repoist\Commands\AppNamespaceDetectorTrait' not found

  [ReflectionException]
  Class Illuminate\Foundation\Composer does not exist
```


