### PR TITLE
Solution to Issue #1 on Laravel 5.4

### DIFF
--- a/src/Commands/RepositoryMakeCommand.php
+++ b/src/Commands/RepositoryMakeCommand.php
@@ -4,14 +4,15 @@ namespace Kurt\Repoist\Commands;
 use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Composer;
 
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 
 class RepositoryMakeCommand extends Command
 {
-    use AppNamespaceDetectorTrait;
-
+    use DetectsApplicationNamespace;
+ 
     /**
      * The console command name.
      *

--- a/src/Commands/RepositoryMakeCommand.php
+++ b/src/Commands/RepositoryMakeCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace Kurt\Repoist\Commands;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 


### PR DESCRIPTION
To fix issue #1 (vendor:publish throws this exception:
 [RuntimeException]                                                                                                                                          
  Error Output: PHP Fatal error:  Trait 'Illuminate\Console\AppNamespaceDetectorTrait' not found in /.../vendor/ozankurt/repoist/src/Commands/RepositoryMakeCommand.php on line 15       
)

Changed use Illuminate\Console\AppNamespaceDetectorTrait; to use Illuminate\Console\DetectsApplicationNamespace;