### PR TITLE
Make package compatible with PHP 7.0.x and fix invalid path when publishing vendor config

### DIFF
--- a/src/Commands/MakeCriterionCommand.php
+++ b/src/Commands/MakeCriterionCommand.php
@@ -61,7 +61,7 @@ class MakeCriterionCommand extends RepoistCommand
         $filePath = $fileDirectory.'/'.$fileName.'.php';
 
         if (!$this->fileManager->exists($fileDirectory)) {
-        	$this->fileManager->makeDirectory($fileDirectory, 755, true);
+        	$this->fileManager->makeDirectory($fileDirectory, 0755, true);
         }
 
         if ($this->laravel->runningInConsole() && $this->fileManager->exists($filePath)) {

--- a/src/Commands/MakeRepositoryCommand.php
+++ b/src/Commands/MakeRepositoryCommand.php
@@ -61,7 +61,7 @@ class MakeRepositoryCommand extends RepoistCommand
     {
         $this->checkModel();
 
-        [$contract, $contractName] = $this->createContract();
+        list($contract, $contractName) = $this->createContract();
 
         $this->createRepository($contract, $contractName);
     }

--- a/src/Commands/MakeRepositoryCommand.php
+++ b/src/Commands/MakeRepositoryCommand.php
@@ -85,7 +85,7 @@ class MakeRepositoryCommand extends RepoistCommand
         $filePath = $fileDirectory.$fileName.'.php';
 
         if (!$this->fileManager->exists($fileDirectory)) {
-        	$this->fileManager->makeDirectory($fileDirectory, 755, true);
+        	$this->fileManager->makeDirectory($fileDirectory, 0755, true);
         }
 
         if ($this->laravel->runningInConsole() && $this->fileManager->exists($filePath)) {
@@ -129,7 +129,7 @@ class MakeRepositoryCommand extends RepoistCommand
 
         // Check if the directory exists, if not create...
         if (!$this->fileManager->exists($fileDirectory)) {
-        	$this->fileManager->makeDirectory($fileDirectory, 755, true);
+        	$this->fileManager->makeDirectory($fileDirectory, 0755, true);
         }
 
         if ($this->laravel->runningInConsole() && $this->fileManager->exists($filePath)) {

--- a/src/RepoistServiceProvider.php
+++ b/src/RepoistServiceProvider.php
@@ -37,7 +37,7 @@ class RepoistServiceProvider extends ServiceProvider
     	$this->mergeConfigFrom(__DIR__.'/config/repoist.php', 'repoist');
 
     	$this->publishes([
-	        __DIR__.'/config/package.php' => config_path('repoist.php')
+	        __DIR__.'/config/repoist.php' => config_path('repoist.php')
 	    ], 'repoist-config');
 
         $this->registerCommands();


### PR DESCRIPTION
- Ensure compatibility with PHP >= 7.0.0 as per Laravel 5.5 minimum requirements
- Fix invalid path when publishing vendor config

Fixes issues #15 and #16.