### PR TITLE
Pagination functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Default methods of the `Kurt\Repoist\Repositories\Eloquent\AbstractRepository`.
 | **update**            | $repo->update($id, array $properties);
 | **delete**            | $repo->delete($id);
 
+Comes with a integrated pagination functions that uses `Illuminate\Pagination\LengthAwarePaginator` to
+return a paginated response if $request->limit > 0
+
 ## Example Usage
 
 Customer.php

--- a/src/Repositories/Eloquent/AbstractRepository.php
+++ b/src/Repositories/Eloquent/AbstractRepository.php
@@ -25,7 +25,7 @@ abstract class AbstractRepository implements RepositoryInterface, CriteriaInterf
     public function __construct(Request $request)
     {
         $this->entity = $this->resolveEntity();
-        $this->request = $request;
+        $this->request = $request; // reading request here allows many options.
     }
 
     /**
@@ -175,7 +175,7 @@ abstract class AbstractRepository implements RepositoryInterface, CriteriaInterf
             // We can bypass and continue...
         } elseif ($this->request->input('limit') > 0){
             // $per_page=null, but we could try find "limit" form request
-            $per_page =  ? $this->request->input('limit') : 0;
+            $per_page = $this->request->input('limit');
         } else {
             return $records;
         }


### PR DESCRIPTION
Check this out. (Haven't tested, maybe needs a fix)

My recommendations its to remove all $perPage, references. clean all that and just just the new function to read directly from request this 2 vars: limit + page.

What I have seen in other libraries its people gives options to set this vars names, I don't think its necessary, you can always overwrite them.

Its up to you, my suggestions:

- Clean, remove all $paginate & $perPage
- move functions specs to the contract and just use the,  `{@inheritdoc}`
- show the contract in the readme for people references.

Simple the better.

